### PR TITLE
Change navigation strategy of auth routes

### DIFF
--- a/src/app/(auth)/index.tsx
+++ b/src/app/(auth)/index.tsx
@@ -22,8 +22,8 @@ export default function AuthIndex() {
   const checkIfUserHasAValidToken = useCallback(async () => {
     const token = await getToken(process.env.EXPO_PUBLIC_TOKEN_KEY!);
 
-    if (token && isBiometricLoginEnabled) router.push("/welcome-back");
-    else router.push("/login");
+    if (token && isBiometricLoginEnabled) router.replace("/welcome-back");
+    else router.replace("/login");
   }, [isBiometricLoginEnabled, router]);
 
   useEffect(() => {

--- a/src/app/(private)/_layout.tsx
+++ b/src/app/(private)/_layout.tsx
@@ -74,7 +74,7 @@ export default function RootLayout() {
     setShowOverlayPrivacyScreen(false);
     CaptureProtection.allow();
 
-    if (!getBiometricPreference()) return router.navigate("/(auth)/login");
+    if (!getBiometricPreference()) return router.replace("/(auth)/login");
 
     if (isAuthenticated) router.replace("/(private)/home");
     else router.replace("/(auth)/welcome-back");

--- a/src/presentation/hooks/useAuth.ts
+++ b/src/presentation/hooks/useAuth.ts
@@ -91,7 +91,7 @@ export function useAuth() {
 
     setTimeout(() => {
       Toast.hide();
-      router.push("/login");
+      router.replace("/login");
     }, 3000);
   };
 

--- a/src/presentation/layouts/PrivateScreenHeaderLayout.tsx
+++ b/src/presentation/layouts/PrivateScreenHeaderLayout.tsx
@@ -17,7 +17,7 @@ export const PrivateScreenHeaderLayout = () => {
   const signOut = async () => {
     try {
       await logout();
-      router.push("/login");
+      router.replace("/login");
     } catch (error) {
       const errorMessage = handleAuthError(error);
       Toast.show({
@@ -29,7 +29,7 @@ export const PrivateScreenHeaderLayout = () => {
   };
 
   return (
-    <SafeAreaView edges={Platform.OS === 'android' ? ['top'] : []}>
+    <SafeAreaView edges={Platform.OS === "android" ? ["top"] : []}>
       <View className='flex-row items-center justify-between pl-1 pr-4 bg-white border-b border-gray-200'>
         <View className='flex-row items-center gap-2 px-4 py-3'>
           <Logo size='xs' />
@@ -53,7 +53,7 @@ export const PrivateScreenHeaderLayout = () => {
           <Avatar name={user?.fullName ?? "Usuário Desconhecido"} />
         </MenuDropDown>
       </View>
-      </SafeAreaView>
+    </SafeAreaView>
   );
 };
 

--- a/src/presentation/pages/CreateAccountPage/index.tsx
+++ b/src/presentation/pages/CreateAccountPage/index.tsx
@@ -80,7 +80,7 @@ export function CreateAccountPage() {
     try {
       await createNewUser(data);
       reset();
-      router.push("/login");
+      router.replace("/login");
     } catch (error) {
       console.error(error);
       const errorMessage = handleAuthError(error);

--- a/src/presentation/pages/LoginPage/index.tsx
+++ b/src/presentation/pages/LoginPage/index.tsx
@@ -59,7 +59,7 @@ export function LoginPage() {
     try {
       await signIn(credentials);
       saveBiometricPreference(enableBiometric);
-      router.push("/home");
+      router.replace("/home");
     } catch (error) {
       const errorMessage = handleAuthError(error);
       Toast.show({

--- a/src/presentation/pages/ResetPasswordPage/index.tsx
+++ b/src/presentation/pages/ResetPasswordPage/index.tsx
@@ -37,7 +37,7 @@ export function ResetPasswordPage() {
   }) => {
     try {
       resetPassword(password);
-      router.push("/login");
+      router.replace("/login");
     } catch (error) {
       const errorMessage = handleAuthError(error);
       Toast.show({


### PR DESCRIPTION
To handle navigation in auth router with more intelligency and efficiency, the made changes replace 'push' and 'navigate' for 'replace' method. Therefore, in these routes the user cannot be able no return to the previous screen.